### PR TITLE
🐛 upsert competency translations

### DIFF
--- a/api/src/domain/competency.ts
+++ b/api/src/domain/competency.ts
@@ -337,9 +337,12 @@ export async function updateCompetencyTranslations(
       data: {
         updatedById: context.userId,
         translations: {
-          updateMany: {
-            data: { title },
-            where: { languageCode },
+          upsert: {
+            create: { title, languageCode },
+            update: { title },
+            where: {
+              competencyId_languageCode: { competencyId: id, languageCode },
+            },
           },
         },
       },

--- a/api/test/competency-mutations.spec.ts
+++ b/api/test/competency-mutations.spec.ts
@@ -880,7 +880,7 @@ describe('renameCompetency', () => {
     expect(response).toHaveProperty('data.renameCompetency.data');
   });
 
-  test('should rename competency', async () => {
+  test('should rename competency in existing locale', async () => {
     const user = await createUserFixture();
     const competency = await createCompetencyFixture();
     const response = await execute<{ renameCompetency: unknown }>(
@@ -906,6 +906,38 @@ describe('renameCompetency', () => {
     expect(response).toHaveProperty(
       'data.renameCompetency.data.title',
       'Hello Universe!',
+    );
+  });
+
+  test('should rename competency in new locale', async () => {
+    const user = await createUserFixture();
+    const competency = await createCompetencyFixture({
+      language: Language.EN,
+      title: 'Hello World!',
+    });
+    const response = await execute<{ renameCompetency: unknown }>(
+      gql`
+        mutation ($id: ID!, $title: String!) {
+          renameCompetency(id: $id, data: { title: $title }) {
+            ... on MutationRenameCompetencySuccess {
+              data {
+                title
+              }
+            }
+          }
+        }
+      `,
+      {
+        spec: { locale: 'nl', userId: user.id },
+        variables: {
+          id: competency.id,
+          title: 'Hallo Wereld!',
+        },
+      },
+    );
+    expect(response).toHaveProperty(
+      'data.renameCompetency.data.title',
+      'Hallo Wereld!',
     );
   });
 });

--- a/app/src/domain/global/components/layout/main-layout.vue
+++ b/app/src/domain/global/components/layout/main-layout.vue
@@ -17,7 +17,10 @@ const { menuState, toggleMenu } = useMenuState();
         @click="toggleMenu()"
       />
       <LoadingSpinner />
-      <UserMenu />
+      <div class="flex gap-3">
+        <LanguageSelect />
+        <UserMenu />
+      </div>
     </div>
     <MainMenu id="mainMenu" :state="menuState" />
     <div


### PR DESCRIPTION
Fixes #292.

A translation in the current user's locale doesn't necessarily already exist when "updating" a competency. Any update to translations should always be an upsert!
