### PR TITLE
💄 generate proper color palette

### DIFF
--- a/app/package.json
+++ b/app/package.json
@@ -26,6 +26,7 @@
     "@formkit/vue": "^1.0.0-beta.8",
     "@headlessui/vue": "^1.6.2",
     "@os/ability": "workspace:*",
+    "@os/css-color-4": "workspace:*",
     "@vue/apollo-composable": "^4.0.0-alpha.17",
     "@vueuse/core": "^8.5.0",
     "graphql": "^16.5.0",

--- a/app/src/domain/competency-management/components/competency-list-page.vue
+++ b/app/src/domain/competency-management/components/competency-list-page.vue
@@ -152,7 +152,7 @@ async function deleteCompetencyHandler(): Promise<void> {
       :open="isDeleteModalOpen"
       @close="isDeleteModalOpen = false"
     >
-      <UiDialogTitle class="text-danger-300">
+      <UiDialogTitle class="text-danger-600">
         <span v-t="'competencies.route.id.index.confirmDeleteModal.heading'" />
       </UiDialogTitle>
       <UiDialogDescription>
@@ -161,11 +161,11 @@ async function deleteCompetencyHandler(): Promise<void> {
           keypath="competencies.route.id.index.confirmDeleteModal.message"
         >
           <template #title>
-            <strong class="text-secondary-300">{{ competency.title }}</strong>
+            <strong class="text-danger-500">{{ competency.title }}</strong>
           </template>
         </i18n-t>
       </UiDialogDescription>
-      <p v-if="deleteErrorMessage" class="text-danger-400">
+      <p v-if="deleteErrorMessage" class="text-danger-600">
         {{ deleteErrorMessage }}
       </p>
       <UiDialogButtons>

--- a/app/src/domain/global/components/layout/debug-layout.vue
+++ b/app/src/domain/global/components/layout/debug-layout.vue
@@ -11,7 +11,7 @@ const breakpoints = useBreakpoints();
       :key="name"
       class=""
     >
-      <div class="px-1 py-1" :class="{ 'bg-secondary-100': active.value }">
+      <div class="px-1 py-1" :class="{ 'bg-primary-100': active.value }">
         {{ name }}
       </div>
     </div>

--- a/app/src/domain/global/components/layout/loading-spinner.vue
+++ b/app/src/domain/global/components/layout/loading-spinner.vue
@@ -16,7 +16,7 @@ const loading = useGlobalQueryLoading();
     <RiLoaderLine
       v-if="loading"
       aria-hidden
-      class="text-lg text-tertiary-300 animate-spin"
+      class="text-lg text-primary-500 animate-spin"
     />
   </Transition>
 </template>

--- a/app/src/domain/global/components/layout/main-menu-toggle-button.vue
+++ b/app/src/domain/global/components/layout/main-menu-toggle-button.vue
@@ -9,12 +9,12 @@ defineProps<{
     :aria-expanded="ariaExpanded"
     aria-haspopup="menu"
     :class="`
-      flex gap-3 items-center px-3 py-2 rounded-md text-base
-      focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-black)
+      flex gap-3 items-center px-3 py-2 rounded-md text-base text-dark-700
+      focus:outline-none focus-visible:(ring-2 ring-dark-700)
     `"
   >
-    <RiMenuFoldLine v-if="ariaExpanded" />
-    <RiMenuLine v-else />
+    <RiMenuFoldLine v-if="ariaExpanded" aria-hidden />
+    <RiMenuLine v-else aria-hidden />
     <span v-t="'global.mainMenu.toggleButton'" />
   </button>
 </template>

--- a/app/src/domain/global/components/layout/main-menu.vue
+++ b/app/src/domain/global/components/layout/main-menu.vue
@@ -25,15 +25,18 @@ defineProps<{
         }"
       >
         <header class="-mb-5">
-          <RouterLink class="flex gap-3 items-center justify-center" to="/">
+          <RouterLink
+            class="flex gap-3 items-center justify-center rounded-md focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-primary-700)"
+            to="/"
+          >
             <img
               alt="OpenSkool logo backpack line art"
-              class="inline-block"
+              class="my-2 inline-block"
               :src="backpackImageUrl"
             />
             <div
               v-t="'global.title'"
-              class="font-normal text-secondary-300 text-xl"
+              class="font-normal text-primary-400 text-xl"
             />
           </RouterLink>
         </header>

--- a/app/src/domain/global/components/layout/user-menu.vue
+++ b/app/src/domain/global/components/layout/user-menu.vue
@@ -18,7 +18,7 @@ const logoutHref = computed(() => {
       <button
         :class="[
           'p-3 border-2 aspect-square rounded-full',
-          'focus:outline-none focus-visible:(ring-2 ring-secondary-300 ring-offset-2)',
+          'focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-primary-700)',
           'flex items-center justify-center',
         ]"
       >
@@ -28,12 +28,12 @@ const logoutHref = computed(() => {
     </UiMenuButton>
     <UiMenuItems>
       <i18n-t
-        class="px-4 py-3 text-base text-gray-500"
+        class="px-4 py-3 text-base text-dark-500"
         keypath="global.userMenu.description"
         tag="div"
       >
         <template #name>
-          <strong class="text-gray-800">{{ authStore.name }}</strong>
+          <strong class="text-primary-800">{{ authStore.name }}</strong>
         </template>
       </i18n-t>
       <UiMenuItem is="a" class="text-base" :href="logoutHref">

--- a/app/src/formkit/plugin.ts
+++ b/app/src/formkit/plugin.ts
@@ -23,9 +23,9 @@ export function formkit(app: App): void {
           global: {
             help: 'text-sm text-gray-600',
             label:
-              'block mb-1 font-bold text-sm formkit-invalid:text-danger-400',
+              'block mb-1 font-bold text-sm formkit-invalid:text-danger-500',
             messages: 'list-none p-0 mt-1 mb-0',
-            message: 'text-danger-300 mb-1 text-sm',
+            message: 'text-danger-500 mb-1 text-sm',
             outer: 'mb-5 opacity-100 formkit-disabled:opacity-40',
           },
           button: BUTTON,

--- a/app/src/pages/demo/ui.vue
+++ b/app/src/pages/demo/ui.vue
@@ -26,6 +26,18 @@ const inputText = ref<string>('');
     </div>
     <div>
       <UiTitle is="h2" class="text-xl">Palette</UiTitle>
+      <UiSubtitle is="h3">Gray</UiSubtitle>
+      <div class="space-x-3">
+        <div class="bg-gray-100 palette" />
+        <div class="bg-gray-200 palette" />
+        <div class="bg-gray-300 palette" />
+        <div class="bg-gray-400 palette" />
+        <div class="bg-gray-500 palette" />
+        <div class="bg-gray-600 palette" />
+        <div class="bg-gray-700 palette" />
+        <div class="bg-gray-800 palette" />
+        <div class="bg-gray-900 palette" />
+      </div>
       <UiSubtitle is="h3">Primary</UiSubtitle>
       <div class="space-x-3">
         <div class="bg-primary-100 palette" />
@@ -34,24 +46,9 @@ const inputText = ref<string>('');
         <div class="bg-primary-400 palette" />
         <div class="bg-primary-500 palette" />
         <div class="bg-primary-600 palette" />
-      </div>
-      <UiSubtitle is="h3">Secondary</UiSubtitle>
-      <div class="space-x-3">
-        <div class="bg-secondary-100 palette" />
-        <div class="bg-secondary-200 palette" />
-        <div class="bg-secondary-300 palette" />
-        <div class="bg-secondary-400 palette" />
-        <div class="bg-secondary-500 palette" />
-        <div class="bg-secondary-600 palette" />
-      </div>
-      <UiSubtitle is="h3">Tertiary</UiSubtitle>
-      <div class="space-x-3">
-        <div class="bg-tertiary-100 palette" />
-        <div class="bg-tertiary-200 palette" />
-        <div class="bg-tertiary-300 palette" />
-        <div class="bg-tertiary-400 palette" />
-        <div class="bg-tertiary-500 palette" />
-        <div class="bg-tertiary-600 palette" />
+        <div class="bg-primary-700 palette" />
+        <div class="bg-primary-800 palette" />
+        <div class="bg-primary-900 palette" />
       </div>
       <UiSubtitle is="h3">Caution</UiSubtitle>
       <div class="space-x-3">
@@ -61,6 +58,9 @@ const inputText = ref<string>('');
         <div class="bg-caution-400 palette" />
         <div class="bg-caution-500 palette" />
         <div class="bg-caution-600 palette" />
+        <div class="bg-caution-700 palette" />
+        <div class="bg-caution-800 palette" />
+        <div class="bg-caution-900 palette" />
       </div>
       <UiSubtitle is="h3">Danger</UiSubtitle>
       <div class="space-x-3">
@@ -70,6 +70,21 @@ const inputText = ref<string>('');
         <div class="bg-danger-400 palette" />
         <div class="bg-danger-500 palette" />
         <div class="bg-danger-600 palette" />
+        <div class="bg-danger-700 palette" />
+        <div class="bg-danger-800 palette" />
+        <div class="bg-danger-900 palette" />
+      </div>
+      <UiSubtitle is="h3">Info</UiSubtitle>
+      <div class="space-x-3">
+        <div class="bg-info-100 palette" />
+        <div class="bg-info-200 palette" />
+        <div class="bg-info-300 palette" />
+        <div class="bg-info-400 palette" />
+        <div class="bg-info-500 palette" />
+        <div class="bg-info-600 palette" />
+        <div class="bg-info-700 palette" />
+        <div class="bg-info-800 palette" />
+        <div class="bg-info-900 palette" />
       </div>
       <UiSubtitle is="h3">Success</UiSubtitle>
       <div class="space-x-3">
@@ -79,35 +94,19 @@ const inputText = ref<string>('');
         <div class="bg-success-400 palette" />
         <div class="bg-success-500 palette" />
         <div class="bg-success-600 palette" />
+        <div class="bg-success-700 palette" />
+        <div class="bg-success-800 palette" />
+        <div class="bg-success-900 palette" />
       </div>
     </div>
-
     <div>
       <UiTitle is="h2" class="text-xl mb-3">Buttons</UiTitle>
-      <div class="space-y-3">
+      <div class="space-y-3 bg-white -m-3 p-3 rounded-md">
         <div class="space-x-3">
           <UiButton color="primary">Button</UiButton>
           <UiButton color="primary" disabled>Button</UiButton>
           <UiButton color="primary" outline>Button</UiButton>
           <UiButton color="primary" disabled outline>Button</UiButton>
-        </div>
-        <div class="space-x-3">
-          <UiButton color="secondary">Button</UiButton>
-          <UiButton color="secondary" disabled>Button</UiButton>
-          <UiButton color="secondary" outline>Button</UiButton>
-          <UiButton color="secondary" disabled outline>Button</UiButton>
-        </div>
-        <div class="space-x-3">
-          <UiButton color="tertiary">Button</UiButton>
-          <UiButton color="tertiary" disabled>Button</UiButton>
-          <UiButton color="tertiary" outline>Button</UiButton>
-          <UiButton color="tertiary" disabled outline>Button</UiButton>
-        </div>
-        <div class="space-x-3">
-          <UiButton color="caution">Button</UiButton>
-          <UiButton color="caution" disabled>Button</UiButton>
-          <UiButton color="caution" outline>Button</UiButton>
-          <UiButton color="caution" disabled outline>Button</UiButton>
         </div>
         <div class="space-x-3">
           <UiButton color="danger">Button</UiButton>
@@ -116,18 +115,8 @@ const inputText = ref<string>('');
           <UiButton color="danger" disabled outline>Button</UiButton>
         </div>
         <div class="space-x-3">
-          <UiButton color="success">Button</UiButton>
-          <UiButton color="success" disabled>Button</UiButton>
-          <UiButton color="success" outline>Button</UiButton>
-          <UiButton color="success" disabled outline>Button</UiButton>
-        </div>
-        <div class="space-x-3">
           <UiButton color="primary" size="sm">Button</UiButton>
-          <UiButton color="secondary" size="sm">Button</UiButton>
-          <UiButton color="tertiary" size="sm">Button</UiButton>
-          <UiButton color="caution" size="sm">Button</UiButton>
           <UiButton color="danger" size="sm">Button</UiButton>
-          <UiButton color="success" size="sm">Button</UiButton>
         </div>
         <div>
           <UiIconButton label="Edit">
@@ -196,12 +185,12 @@ const inputText = ref<string>('');
         <UiMenuItems>
           <div class="px-4 py-3">
             <div class="font-bold">Dieter Luypaert</div>
-            <small class="text-secondary-400 underline">
+            <small class="text-primary-400 underline">
               dieter@foursevens.be
             </small>
           </div>
           <UiMenuItem>
-            <RiPencilLine aria-hidden="true" class="text-secondary-400" />
+            <RiPencilLine aria-hidden="true" class="text-primary-400" />
             Edit
           </UiMenuItem>
           <UiMenuItem>

--- a/app/src/ui/breadcrumb/ui-breadcrumb-item.vue
+++ b/app/src/ui/breadcrumb/ui-breadcrumb-item.vue
@@ -8,7 +8,7 @@ defineProps<{
   <li class="inline text-gray-600 text-sm uppercase">
     <RouterLink
       v-if="linkTo"
-      class="hover:underline rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2"
+      class="-m-1 p-1 hover:underline rounded-sm focus:outline-none focus-visible:(ring-2 ring-dark-700)"
       :to="linkTo"
     >
       <slot />

--- a/app/src/ui/button/helpers.ts
+++ b/app/src/ui/button/helpers.ts
@@ -10,13 +10,7 @@ type ClassValue =
   | undefined;
 
 export interface ButtonStyleOptions {
-  color?:
-    | 'primary'
-    | 'secondary'
-    | 'tertiary'
-    | 'caution'
-    | 'danger'
-    | 'success';
+  color?: 'primary' | 'danger';
   disabled?: boolean;
   outline?: boolean;
   size?: 'sm' | 'base';
@@ -54,55 +48,19 @@ export function createButtonStyles({
     switch (color) {
       case 'primary': {
         classes.push(
-          'border-2 border-primary-300 ring-primary-500',
+          'border-2 ring-primary-700',
           outline
-            ? 'text-primary-600 active:border-primary-400'
-            : 'text-primary-600 bg-primary-300 active:(bg-primary-400 border-primary-400)',
-        );
-        break;
-      }
-      case 'secondary': {
-        classes.push(
-          'border-2 border-secondary-300 ring-secondary-500',
-          outline
-            ? 'text-secondary-600 active:border-secondary-500'
-            : 'text-white bg-secondary-300 active:(bg-secondary-400 border-secondary-400)',
-        );
-        break;
-      }
-      case 'tertiary': {
-        classes.push(
-          'border-2 border-tertiary-300 ring-tertiary-500',
-          outline
-            ? 'text-tertiary-600 active:border-tertiary-500'
-            : 'text-white bg-tertiary-300 active:(bg-tertiary-400 border-tertiary-400)',
-        );
-        break;
-      }
-      case 'caution': {
-        classes.push(
-          'border-2 border-caution-300 ring-caution-500',
-          outline
-            ? 'text-caution-600 active:border-caution-400'
-            : 'text-caution-600 bg-caution-300 active:(bg-caution-400 border-caution-400)',
+            ? 'text-primary-700 border-primary-400 active:border-primary-600'
+            : 'text-white bg-primary-400 border-primary-400 active:(bg-primary-500 border-primary-500)',
         );
         break;
       }
       case 'danger': {
         classes.push(
-          'border-2 border-danger-300 ring-danger-500',
+          'border-2 ring-danger-700',
           outline
-            ? 'text-danger-600 active:border-danger-500'
-            : 'text-white bg-danger-300 active:(bg-danger-400 border-danger-400)',
-        );
-        break;
-      }
-      case 'success': {
-        classes.push(
-          'border-2 border-success-300 ring-success-500',
-          outline
-            ? 'text-success-600 active:border-success-500'
-            : 'text-success-600 bg-success-300 active:(bg-success-400 border-success-400)',
+            ? 'text-danger-700 border-danger-400 active:border-danger-600'
+            : 'text-white bg-danger-400 border-danger-400 active:(bg-danger-500 border-danger-500)',
         );
         break;
       }

--- a/app/src/ui/button/ui-button-link.vue
+++ b/app/src/ui/button/ui-button-link.vue
@@ -2,13 +2,7 @@
 import { createButtonStyles } from './helpers';
 
 const props = defineProps<{
-  color?:
-    | 'primary'
-    | 'secondary'
-    | 'tertiary'
-    | 'caution'
-    | 'danger'
-    | 'success';
+  color?: 'primary' | 'danger';
   outline?: boolean;
   size?: 'sm' | 'base';
 }>();

--- a/app/src/ui/button/ui-button-router-link.vue
+++ b/app/src/ui/button/ui-button-router-link.vue
@@ -2,13 +2,7 @@
 import { createButtonStyles } from './helpers';
 
 const props = defineProps<{
-  color?:
-    | 'primary'
-    | 'secondary'
-    | 'tertiary'
-    | 'caution'
-    | 'danger'
-    | 'success';
+  color?: 'primary' | 'danger';
   outline?: boolean;
   size?: 'sm' | 'base';
 }>();

--- a/app/src/ui/button/ui-button.vue
+++ b/app/src/ui/button/ui-button.vue
@@ -2,13 +2,7 @@
 import { createButtonStyles } from './helpers';
 
 const props = defineProps<{
-  color?:
-    | 'primary'
-    | 'secondary'
-    | 'tertiary'
-    | 'caution'
-    | 'danger'
-    | 'success';
+  color?: 'primary' | 'danger';
   disabled?: boolean;
   outline?: boolean;
   size?: 'sm' | 'base';

--- a/app/src/ui/dialog/ui-dialog.vue
+++ b/app/src/ui/dialog/ui-dialog.vue
@@ -41,14 +41,14 @@ defineEmits<(event: 'close') => void>();
           >
             <div v-if="implicitClose" class="absolute top-0 right-0 p-3">
               <button
-                class="flex rounded-lg p-2 text-gray-500 focus:outline-none focus-visible:(ring-2 ring-gray-500)"
+                class="flex rounded-lg p-2 text-dark-700 focus:outline-none focus-visible:(ring-2 ring-dark-700)"
                 type="button"
                 @click="$emit('close')"
               >
                 <RiCloseLine />
               </button>
             </div>
-            <div class="space-y-5">
+            <div class="space-y-8">
               <slot />
             </div>
           </div>

--- a/app/src/ui/input/ui-checkbox.vue
+++ b/app/src/ui/input/ui-checkbox.vue
@@ -13,8 +13,8 @@ defineProps<{
       <input
         :class="[
           'center w-5 h-5 pointer-events-none',
-          'bg-white rounded-sm checked:bg-secondary-300',
-          'focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-secondary-400)',
+          'bg-white rounded-sm checked:bg-primary-400',
+          'focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-primary-700)',
           'disabled:bg-stone-300',
         ]"
         :disabled="disabled"

--- a/app/src/ui/input/ui-input-text.vue
+++ b/app/src/ui/input/ui-input-text.vue
@@ -9,7 +9,7 @@ defineEmits<(event: 'update:modelValue', value: string) => void>();
 
 <template>
   <input
-    class="inline-block text-base py-2 px-3 bg-white rounded-md shadow-md border-1 border-gray-200 focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-secondary-400)"
+    class="inline-block text-base py-2 px-3 bg-white rounded-md shadow-md border-1 border-gray-200 focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-primary-700)"
     type="text"
     :disabled="disabled"
     :value="modelValue"

--- a/app/src/ui/input/ui-radio.vue
+++ b/app/src/ui/input/ui-radio.vue
@@ -12,8 +12,8 @@ defineProps<{
     <input
       :class="[
         'relative w-5 h-5',
-        'bg-white rounded-full checked:bg-secondary-300',
-        'focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-secondary-400)',
+        'bg-white rounded-full checked:bg-primary-400',
+        'focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-primary-700)',
         'disabled:bg-stone-300 disabled:cursor-not-allowed',
       ]"
       :disabled="disabled"

--- a/app/src/ui/list/ui-ordered-list-item.vue
+++ b/app/src/ui/list/ui-ordered-list-item.vue
@@ -16,20 +16,20 @@ defineEmits<(event: 'moveUp' | 'moveDown') => void>();
       :class="[
         'flex-1 flex px-10 py-5 bg-white text-base',
         'first-of-type:rounded-t-lg last-of-type:rounded-b-lg',
-        'select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2',
-        'hover:bg-gray-300/50',
+        'select-none focus:outline-none focus-visible:(ring-2 ring-primary-700)',
+        'hover:bg-gray-200',
       ]"
     >
       <div v-if="showArrows" class="absolute inset-0">
         <button
-          class="arrow-up top-0 rounded-lg select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 hover:bg-white"
+          class="arrow-up top-0 rounded-lg select-none focus:outline-none focus-visible:(ring-2 ring-dark-700) hover:bg-white"
           @click.prevent="$emit('moveUp')"
         >
           <span v-if="moveUpText" class="sr-only">{{ moveUpText }}</span>
           <RiArrowUpLine aria-hidden />
         </button>
         <button
-          class="arrow-down bottom-0 rounded-lg select-none focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 hover:bg-white"
+          class="arrow-down bottom-0 rounded-lg select-none focus:outline-none focus-visible:(ring-2 ring-dark-700) hover:bg-white"
           @click.prevent="$emit('moveDown')"
         >
           <span v-if="moveDownText" class="sr-only">{{ moveDownText }}</span>

--- a/app/src/ui/main-nav/ui-main-nav-link.vue
+++ b/app/src/ui/main-nav/ui-main-nav-link.vue
@@ -1,9 +1,9 @@
 <template>
   <RouterLink
-    active-class="bg-secondary-200/50 font-medium"
+    active-class="bg-primary-200/50 font-medium"
     :class="[
-      'block px-3 py-2 rounded-md hover:bg-gray-300/50',
-      'focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-secondary-400)',
+      'block px-3 py-2 rounded-md hover:bg-gray-200',
+      'focus:outline-none focus-visible:(ring-2 ring-primary-700)',
     ]"
   >
     <slot />

--- a/app/src/ui/menu/ui-menu-item.vue
+++ b/app/src/ui/menu/ui-menu-item.vue
@@ -12,7 +12,7 @@ defineProps<{
       :is="is ?? 'button'"
       :class="[
         'w-full flex gap-3 items-center px-4 py-3 rounded-md',
-        { 'bg-primary-200': active },
+        { 'bg-primary-100': active },
       ]"
     >
       <slot v-bind="{ active, disabled }" />

--- a/app/src/ui/select/ui-select-option.vue
+++ b/app/src/ui/select/ui-select-option.vue
@@ -16,8 +16,8 @@ defineProps<{
         disabled
           ? 'bg-stone-200 text-stone-500 cursor-not-allowed'
           : active
-          ? 'text-gray-800 bg-secondary-100'
-          : 'text-gray-900',
+          ? 'text-dark-800 bg-primary-100'
+          : 'text-dark-900',
       ]"
     >
       <div class="truncate" :class="selected ? 'font-medium' : 'font-normal'">
@@ -25,7 +25,7 @@ defineProps<{
       </div>
       <span
         v-if="selected"
-        class="absolute inset-y-0 left-0 flex items-center pl-3 text-primary-600"
+        class="absolute inset-y-0 left-0 flex items-center pl-3 text-primary-700"
       >
         <RiCheckLine aria-hidden="true" class="w-5 h-5" />
       </span>

--- a/app/src/ui/select/ui-select.vue
+++ b/app/src/ui/select/ui-select.vue
@@ -23,7 +23,7 @@ defineEmits<
           'toggle-button',
           'flex items-center justify-between px-3 py-2',
           'bg-white rounded-md shadow-md border-1 border-gray-200',
-          'focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-secondary-400)',
+          'focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-primary-700)',
           'cursor-default select-none',
         ]"
       >

--- a/app/src/ui/switch/ui-switch.vue
+++ b/app/src/ui/switch/ui-switch.vue
@@ -10,15 +10,15 @@ defineEmits<(event: 'update:modelValue', value: boolean) => void>();
 <template>
   <Switch
     :model-value="modelValue"
-    :class="modelValue ? 'bg-primary-400' : 'bg-primary-500'"
-    class="relative inline-flex flex-shrink-0 h-[38px] w-[74px] border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-primary-500)"
+    :class="modelValue ? 'bg-primary-400' : 'bg-primary-600'"
+    class="relative inline-flex flex-shrink-0 h-38px w-74px border-2 border-transparent rounded-full cursor-pointer transition-colors ease-in-out duration-200 focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-primary-700)"
     @update:model-value="$emit('update:modelValue', $event)"
   >
     <span class="sr-only">{{ label }}</span>
     <span
       aria-hidden="true"
       :class="modelValue ? 'translate-x-9' : 'translate-x-0'"
-      class="pointer-events-none inline-block h-[34px] w-[34px] rounded-full bg-white shadow-lg transform ring-0 transition ease-in-out duration-200"
+      class="pointer-events-none inline-block h-34px w-34px rounded-full bg-white shadow-lg transform transition ease-in-out duration-200"
     />
   </Switch>
 </template>

--- a/app/src/ui/tabs/ui-tab.vue
+++ b/app/src/ui/tabs/ui-tab.vue
@@ -6,7 +6,7 @@ defineProps<{
 
 <template>
   <TabPanel
-    class="px-3 py-2 rounded-sm focus:outline-none focus-visible:(ring-2 ring-offset-2)"
+    class="px-3 py-2 rounded-sm focus:outline-none focus-visible:(ring-2 ring-offset-2 ring-dark-700)"
   >
     <slot />
   </TabPanel>

--- a/app/src/ui/tabs/ui-tabs.vue
+++ b/app/src/ui/tabs/ui-tabs.vue
@@ -9,17 +9,17 @@
       >
         <button
           :class="[
-            'px-5 py-2 select-none whitespace-nowrap',
+            'px-8 py-2 select-none whitespace-nowrap',
             'font-semibold text-sm text-primary-600 uppercase border-b-2',
-            selected ? 'border-b-secondary-300' : 'border-b-transparent-300',
-            'rounded-t-sm focus:outline-none focus-visible:ring-2',
+            selected ? 'border-b-primary-400' : 'border-b-transparent-300',
+            'rounded-t-sm focus:outline-none focus-visible:(ring-2 ring-offset-5 ring-primary-700)',
           ]"
         >
           {{ slot.props?.title }}
         </button>
       </Tab>
     </TabList>
-    <TabPanels class="focus:outline-none focus-visible:(ring-2 ring-offset-2)">
+    <TabPanels class="focus:outline-none focus-visible:(ring-2 ring-dark-700)">
       <slot />
     </TabPanels>
   </TabGroup>

--- a/app/src/ui/title/ui-title.vue
+++ b/app/src/ui/title/ui-title.vue
@@ -5,7 +5,7 @@ defineProps<{
 </script>
 
 <template>
-  <Component :is="is ?? 'div'" class="font-semibold text-secondary-300">
+  <Component :is="is ?? 'div'" class="font-semibold text-primary-500">
     <slot />
   </Component>
 </template>

--- a/app/themes/ugent.ts
+++ b/app/themes/ugent.ts
@@ -1,11 +1,23 @@
-import { baseColors, baseTheme, createConfig } from '../windicss';
+import {
+  baseColors,
+  baseTheme,
+  createConfig,
+  generateRange,
+} from '../windicss';
+
+//  UGent Blue:
+//    #1D64C8
+//    https://oklch.evilmartians.io/#51.87,0.17,258.32,100
+//    { chroma: 0.17, hue: 258.32 }
 
 export default createConfig({
   ...baseTheme,
   colors: {
     ...baseTheme.colors,
-    primary: baseColors.secondary,
-    secondary: baseColors.primary,
+    primary: generateRange({
+      chroma: 0.17,
+      hue: 258.32,
+    }) as typeof baseColors.primary,
   },
   extend: {
     borderRadius: {

--- a/app/windicss/color-helpers.ts
+++ b/app/windicss/color-helpers.ts
@@ -1,0 +1,42 @@
+import { oklchToSRgb } from '@os/css-color-4';
+
+/* eslint-disable @typescript-eslint/no-magic-numbers */
+
+const toHex = (number: number, maxLength = 2): string =>
+  number.toString(16).padStart(maxLength, '0');
+
+export function generateRange({
+  lightness: { from = 95, steps = 9, to = 17 } = {},
+  chroma = 0.162,
+  hue,
+}: {
+  lightness?: { from?: number; steps?: number; to?: number };
+  chroma?: number;
+  hue: number;
+}): Record<string, string> {
+  if (
+    from < to ||
+    from > 99 ||
+    to < 15 ||
+    chroma < 0 ||
+    chroma > 230 ||
+    hue < 0 ||
+    hue > 360
+  ) {
+    throw new RangeError('HCL color range out of bounds');
+  }
+  // console.log(`-- RANGE ${chroma} / ${hue} --`);
+  const range: Record<string, string> = {};
+  const lightnessGap = (from - to) / (steps - 1);
+  let lightness = from;
+  for (let step = 1; step <= steps; step += 1) {
+    const [r, g, b] = oklchToSRgb([lightness / 100, chroma, hue]);
+    const hex = `#${toHex(r)}${toHex(g)}${toHex(b)}`;
+    // console.log(
+    //   `step ${step} – rgb: ${r} ${g} ${b} – lch ${lightness}% ${chroma} ${hue} – hex ${hex}`,
+    // );
+    range[`${step}00`] = hex;
+    lightness -= lightnessGap;
+  }
+  return range;
+}

--- a/app/windicss/create-config.ts
+++ b/app/windicss/create-config.ts
@@ -16,7 +16,7 @@ const BASE_COLORS = [
   'white',
 ];
 
-const WINDI_COLORS = ['dark', 'light', 'neutral', 'slate', 'stone', 'zinc'];
+const WINDI_COLORS = ['dark', 'light', 'stone'];
 
 export default function createConfig(theme: OsTheme): FullConfig {
   return {

--- a/app/windicss/index.ts
+++ b/app/windicss/index.ts
@@ -1,2 +1,3 @@
 export { default as createConfig } from './create-config';
+export * from './color-helpers';
 export * from './tokens';

--- a/app/windicss/tokens.ts
+++ b/app/windicss/tokens.ts
@@ -1,26 +1,20 @@
 import windiColors from 'windicss/colors';
 import { Theme } from 'windicss/types/interfaces';
 
-type ReasonableRange = 1 | 2 | 3 | 4 | 5 | 6;
-export type ReasonableColors = {
-  [Range in ReasonableRange as `${Range}00`]: string;
-};
+import { generateRange } from './color-helpers';
 
-type WindiRange = ReasonableRange | 7 | 8 | 9;
+type WindiRange = 1 | 2 | 3 | 4 | 5 | 6 | 7 | 8 | 9;
 export type WindiColors = {
   [Range in WindiRange as `${Range}00`]: string;
 };
 
 export interface OsColors {
-  primary: ReasonableColors;
-  secondary: ReasonableColors;
-  tertiary: ReasonableColors;
-
-  caution: ReasonableColors;
-  danger: ReasonableColors;
-  success: ReasonableColors;
-
   gray: WindiColors;
+  primary: WindiColors;
+  caution: WindiColors;
+  danger: WindiColors;
+  info: WindiColors;
+  success: WindiColors;
 }
 
 export interface OsTheme {
@@ -28,57 +22,51 @@ export interface OsTheme {
   extend?: Theme;
 }
 
+//  OS Blue:
+//    #2A6DF7
+//    https://oklch.evilmartians.io/#57.65,0.218,262.38,100
+//    { chroma: 0.218, hue: 262.38 }
+//
+//  OS Orange
+//    #F6BF45
+//    https://oklch.evilmartians.io/#83.35,0.147,83.57,100
+//    { chroma: 0.147, hue: 83.57 }
+//
+//  OS Red:
+//    #D32E64
+//    https://oklch.evilmartians.io/#57.7,0.201,7.34,100
+//    { chroma: 0.201, hue: 7.34 }
+
+// Windi gray options:
+//   'warmGray' | 'trueGray' | 'gray' | 'coolGray' | 'blueGray' | 'slate' | 'zinc' | 'neutral' | 'stone'
+
 export const baseColors: OsColors = {
-  primary: {
-    100: '#fff6e7',
-    200: '#fff5bf',
-    300: '#f6bf44',
-    400: '#c3931b',
-    500: '#7d5500',
-    600: '#402200',
-  },
-  secondary: {
-    100: '#dcf9ff',
-    200: '#c0e0ff',
-    300: '#2a6ef6',
-    400: '#005ade',
-    500: '#00107c',
-    600: '#000039',
-  },
-  tertiary: {
-    100: '#ffe2e8',
-    200: '#ffb9dd',
-    300: '#d32e64',
-    400: '#c31457',
-    500: '#830028',
-    600: '#440004',
-  },
-  caution: {
-    100: '#fff6e7',
-    200: '#fff5bf',
-    300: '#f6bf44',
-    400: '#c3931b',
-    500: '#7d5500',
-    600: '#402200',
-  },
-  danger: {
-    100: '#ffefe9',
-    200: '#ffd3c3',
-    300: '#f54242',
-    400: '#d00c2a',
-    500: '#7b0000',
-    600: '#3f0000',
-  },
-  success: {
-    100: '#e0ffe2',
-    200: '#b0ffb5',
-    300: '#79de81',
-    400: '#44a952',
-    500: '#00691a',
-    600: '#004200',
-  },
-  // Gray options: 'warmGray' | 'trueGray' | 'gray' | 'coolGray' | 'blueGray' | 'slate' | 'zinc' | 'neutral' | 'stone'
-  gray: windiColors.gray as WindiColors,
+  gray: windiColors.slate as WindiColors,
+  primary: generateRange({
+    lightness: { from: 94 },
+    chroma: 0.218,
+    hue: 262.38,
+  }) as WindiColors,
+  caution: generateRange({
+    lightness: { from: 99, to: 25 },
+    chroma: 0.147,
+    hue: 83.57,
+  }) as WindiColors,
+  danger: generateRange({
+    lightness: { from: 93 },
+    chroma: 0.201,
+    hue: 7.34,
+  }) as WindiColors,
+  info: generateRange({
+    lightness: { from: 90 },
+    chroma: 0.204,
+    hue: 293.91,
+  }) as WindiColors,
+  success: generateRange({
+    lightness: { from: 90 },
+    chroma: 0.082,
+    hue: 126.93,
+  }) as WindiColors,
 };
 
 export const baseTheme: OsTheme = {

--- a/libs/css-color-4/README.md
+++ b/libs/css-color-4/README.md
@@ -1,0 +1,15 @@
+# CSS color level 4
+
+Almost all code lifted from [PostCSS OkLab plugin](https://github.com/csstools/postcss-plugins/tree/main/plugins/postcss-oklab-function), who in turn lifted their implementation from the [CSS WG](https://github.com/w3c/csswg-drafts/tree/main/css-color-4).
+
+This code is used in our Windi themes to write color ranges in [LCH](https://developer.mozilla.org/en-US/docs/Web/CSS/color_value/lch) and transform them into RGB hex values.
+
+## Windi support
+
+If [color-string](https://github.com/Qix-/color-string/) implement [CSS level 4 support](https://github.com/Qix-/color-string/issues/27) we can remove all of this again and directly code our colors in LCH.
+
+Windi (who uses color-string) to parse the configured colors will compile and transform them into hex values for us.
+
+## Browser support
+
+Then even later if all ever-green browsers support the LCH color space natively Windi can even choose to not compile them into RGB hex values. That's probably still a good way down the line.

--- a/libs/css-color-4/package.json
+++ b/libs/css-color-4/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@os/css-color-4",
+  "version": "1.0.0",
+  "private": true,
+  "license": "AGPL-3.0",
+  "main": "dist/index.js",
+  "type": "module",
+  "engines": {
+    "node": "16.15.0"
+  },
+  "scripts": {
+    "build": "rollup -c",
+    "clean": "rm -rf .turbo/ dist/",
+    "dev": "rollup -c -w"
+  },
+  "files": [
+    "dist/"
+  ],
+  "devDependencies": {
+    "rollup": "^2.74.1",
+    "rollup-plugin-dts": "^4.2.1",
+    "rollup-plugin-esbuild": "^4.9.1",
+    "typescript": "~4.7.2"
+  },
+  "types": "dist/index.d.ts"
+}

--- a/libs/css-color-4/rollup.config.mjs
+++ b/libs/css-color-4/rollup.config.mjs
@@ -1,0 +1,28 @@
+import dts from 'rollup-plugin-dts';
+import esbuild from 'rollup-plugin-esbuild';
+
+const bundle = (config) => ({
+  ...config,
+  input: 'src/index.ts',
+  external: (id) => !/^[./]/.test(id),
+});
+
+export default [
+  bundle({
+    plugins: [esbuild()],
+    output: [
+      {
+        file: `dist/index.js`,
+        format: 'es',
+        sourcemap: true,
+      },
+    ],
+  }),
+  bundle({
+    plugins: [dts()],
+    output: {
+      file: `dist/index.d.ts`,
+      format: 'es',
+    },
+  }),
+];

--- a/libs/css-color-4/src/convert-oklch-to-srgb.ts
+++ b/libs/css-color-4/src/convert-oklch-to-srgb.ts
@@ -1,0 +1,59 @@
+import {
+  gam_sRGB,
+  lin_sRGB,
+  lin_sRGB_to_XYZ,
+  OKLab_to_OKLCH,
+  OKLab_to_XYZ,
+  OKLCH_to_OKLab,
+  XYZ_to_lin_sRGB,
+  XYZ_to_OKLab,
+} from './css-color-4/conversions';
+import { clip, inGamut, mapGamut } from './css-color-4/map-gamut';
+
+type color = [number, number, number];
+
+export function oklchToSRgb(oklchRaw: color): color {
+  const [oklchLRaw, oklchCRaw, oklchHRaw] = oklchRaw;
+
+  const oklchL = Math.max(oklchLRaw, 0);
+
+  const oklch = [oklchL, oklchCRaw, oklchHRaw % 360] as color;
+
+  let conversion = oklch as color;
+  if (conversion[0] < 0.000001) {
+    conversion = [0, 0, 0] as color;
+  }
+
+  if (conversion[0] > 0.999999) {
+    conversion = [1, 0, 0] as color;
+  }
+
+  conversion = OKLCH_to_OKLab(conversion);
+  conversion = OKLab_to_XYZ(conversion);
+  conversion = XYZ_to_lin_sRGB(conversion);
+  conversion = gam_sRGB(conversion);
+
+  if (inGamut(conversion)) {
+    return clip(conversion).map((x) => {
+      return Math.round(x * 255);
+    }) as color;
+  }
+
+  return mapGamut(
+    oklch,
+    (x: color) => {
+      x = OKLCH_to_OKLab(x);
+      x = OKLab_to_XYZ(x);
+      x = XYZ_to_lin_sRGB(x);
+      return gam_sRGB(x);
+    },
+    (x: color) => {
+      x = lin_sRGB(x);
+      x = lin_sRGB_to_XYZ(x);
+      x = XYZ_to_OKLab(x);
+      return OKLab_to_OKLCH(x);
+    },
+  ).map((x) => {
+    return Math.round(x * 255);
+  }) as color;
+}

--- a/libs/css-color-4/src/css-color-4/LICENSE.md
+++ b/libs/css-color-4/src/css-color-4/LICENSE.md
@@ -1,0 +1,5 @@
+All documents in this Directory are licensed by contributors
+under the 
+[W3C Software and Document License](https://www.w3.org/Consortium/Legal/copyright-software).
+
+See [w3c/csswg-drafts](https://github.com/w3c/csswg-drafts) for the original work.

--- a/libs/css-color-4/src/css-color-4/conversions.ts
+++ b/libs/css-color-4/src/css-color-4/conversions.ts
@@ -1,0 +1,526 @@
+/**
+ * @license W3C
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ *
+ * @copyright This software or document includes material copied from or derived from https://github.com/w3c/csswg-drafts/blob/main/css-color-4/conversions.js. Copyright © 2022 W3C® (MIT, ERCIM, Keio, Beihang).
+ *
+ * @see https://github.com/w3c/csswg-drafts/blob/main/css-color-4/conversions.js
+ */
+
+/* eslint-disable @typescript-eslint/no-loss-of-precision */
+
+import { multiplyMatrices } from './multiply-matrices';
+
+type color = [number, number, number];
+
+// Sample code for color conversions
+// Conversion can also be done using ICC profiles and a Color Management System
+// For clarity, a library is used for matrix multiplication (multiply-matrices.js)
+
+// standard white points, defined by 4-figure CIE x,y chromaticities
+export const D50 = [0.3457 / 0.3585, 1.0, (1.0 - 0.3457 - 0.3585) / 0.3585];
+export const D65 = [0.3127 / 0.329, 1.0, (1.0 - 0.3127 - 0.329) / 0.329];
+
+// sRGB-related functions
+
+export function lin_sRGB(RGB: color): color {
+  // convert an array of sRGB values
+  // where in-gamut values are in the range [0 - 1]
+  // to linear light (un-companded) form.
+  // https://en.wikipedia.org/wiki/SRGB
+  // Extended transfer function:
+  // for negative values,  linear portion is extended on reflection of axis,
+  // then reflected power function is used.
+  return RGB.map(function (val) {
+    const sign = val < 0 ? -1 : 1;
+    const abs = Math.abs(val);
+
+    if (abs < 0.04045) {
+      return val / 12.92;
+    }
+
+    return sign * Math.pow((abs + 0.055) / 1.055, 2.4);
+  }) as color;
+}
+
+export function gam_sRGB(RGB: color): color {
+  // convert an array of linear-light sRGB values in the range 0.0-1.0
+  // to gamma corrected form
+  // https://en.wikipedia.org/wiki/SRGB
+  // Extended transfer function:
+  // For negative values, linear portion extends on reflection
+  // of axis, then uses reflected pow below that
+  return RGB.map(function (val) {
+    const sign = val < 0 ? -1 : 1;
+    const abs = Math.abs(val);
+
+    if (abs > 0.0031308) {
+      return sign * (1.055 * Math.pow(abs, 1 / 2.4) - 0.055);
+    }
+
+    return 12.92 * val;
+  }) as color;
+}
+
+export function lin_sRGB_to_XYZ(rgb: color): color {
+  // convert an array of linear-light sRGB values to CIE XYZ
+  // using sRGB's own white, D65 (no chromatic adaptation)
+
+  const M = [
+    [0.41239079926595934, 0.357584339383878, 0.1804807884018343],
+    [0.21263900587151027, 0.715168678767756, 0.07219231536073371],
+    [0.01933081871559182, 0.11919477979462598, 0.9505321522496607],
+  ];
+  return multiplyMatrices(M, rgb) as color;
+}
+
+export function XYZ_to_lin_sRGB(XYZ: color): color {
+  // convert XYZ to linear-light sRGB
+
+  const M = [
+    [3.2409699419045226, -1.537383177570094, -0.4986107602930034],
+    [-0.9692436362808796, 1.8759675015077202, 0.04155505740717559],
+    [0.05563007969699366, -0.20397695888897652, 1.0569715142428786],
+  ];
+
+  return multiplyMatrices(M, XYZ) as color;
+}
+
+//  display-p3-related functions
+
+export function lin_P3(RGB: color): color {
+  // convert an array of display-p3 RGB values in the range 0.0 - 1.0
+  // to linear light (un-companded) form.
+
+  return lin_sRGB(RGB); // same as sRGB
+}
+
+export function gam_P3(RGB: color): color {
+  // convert an array of linear-light display-p3 RGB  in the range 0.0-1.0
+  // to gamma corrected form
+
+  return gam_sRGB(RGB); // same as sRGB
+}
+
+export function lin_P3_to_XYZ(rgb: color): color {
+  // convert an array of linear-light display-p3 values to CIE XYZ
+  // using  D65 (no chromatic adaptation)
+  // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+  const M = [
+    [0.4865709486482162, 0.26566769316909306, 0.1982172852343625],
+    [0.2289745640697488, 0.6917385218365064, 0.079286914093745],
+    [0.0, 0.04511338185890264, 1.043944368900976],
+  ];
+  // 0 was computed as -3.972075516933488e-17
+
+  return multiplyMatrices(M, rgb) as color;
+}
+
+export function XYZ_to_lin_P3(XYZ: color): color {
+  // convert XYZ to linear-light P3
+  const M = [
+    [2.493496911941425, -0.9313836179191239, -0.40271078445071684],
+    [-0.8294889695615747, 1.7626640603183463, 0.023624685841943577],
+    [0.03584583024378447, -0.07617238926804182, 0.9568845240076872],
+  ];
+
+  return multiplyMatrices(M, XYZ) as color;
+}
+
+// prophoto-rgb functions
+
+export function lin_ProPhoto(RGB: color): color {
+  // convert an array of prophoto-rgb values
+  // where in-gamut colors are in the range [0.0 - 1.0]
+  // to linear light (un-companded) form.
+  // Transfer curve is gamma 1.8 with a small linear portion
+  // Extended transfer function
+  const Et2 = 16 / 512;
+  return RGB.map(function (val) {
+    const sign = val < 0 ? -1 : 1;
+    const abs = Math.abs(val);
+
+    if (abs <= Et2) {
+      return val / 16;
+    }
+
+    return sign * Math.pow(val, 1.8);
+  }) as color;
+}
+
+export function gam_ProPhoto(RGB: color): color {
+  // convert an array of linear-light prophoto-rgb  in the range 0.0-1.0
+  // to gamma corrected form
+  // Transfer curve is gamma 1.8 with a small linear portion
+  // TODO for negative values, extend linear portion on reflection of axis, then add pow below that
+  const Et = 1 / 512;
+  return RGB.map(function (val) {
+    const sign = val < 0 ? -1 : 1;
+    const abs = Math.abs(val);
+
+    if (abs >= Et) {
+      return sign * Math.pow(abs, 1 / 1.8);
+    }
+
+    return 16 * val;
+  }) as color;
+}
+
+export function lin_ProPhoto_to_XYZ(rgb: color): color {
+  // convert an array of linear-light prophoto-rgb values to CIE XYZ
+  // using  D50 (so no chromatic adaptation needed afterwards)
+  // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+  const M = [
+    [0.7977604896723027, 0.13518583717574031, 0.0313493495815248],
+    [0.2880711282292934, 0.7118432178101014, 0.00008565396060525902],
+    [0.0, 0.0, 0.8251046025104601],
+  ];
+
+  return multiplyMatrices(M, rgb) as color;
+}
+
+export function XYZ_to_lin_ProPhoto(XYZ: color): color {
+  // convert XYZ to linear-light prophoto-rgb
+  const M = [
+    [1.3457989731028281, -0.25558010007997534, -0.05110628506753401],
+    [-0.5446224939028347, 1.5082327413132781, 0.02053603239147973],
+    [0.0, 0.0, 1.2119675456389454],
+  ];
+
+  return multiplyMatrices(M, XYZ) as color;
+}
+
+// a98-rgb functions
+
+export function lin_a98rgb(RGB: color): color {
+  // convert an array of a98-rgb values in the range 0.0 - 1.0
+  // to linear light (un-companded) form.
+  // negative values are also now accepted
+  return RGB.map(function (val) {
+    const sign = val < 0 ? -1 : 1;
+    const abs = Math.abs(val);
+
+    return sign * Math.pow(abs, 563 / 256);
+  }) as color;
+}
+
+export function gam_a98rgb(RGB: color): color {
+  // convert an array of linear-light a98-rgb  in the range 0.0-1.0
+  // to gamma corrected form
+  // negative values are also now accepted
+  return RGB.map(function (val) {
+    const sign = val < 0 ? -1 : 1;
+    const abs = Math.abs(val);
+
+    return sign * Math.pow(abs, 256 / 563);
+  }) as color;
+}
+
+export function lin_a98rgb_to_XYZ(rgb: color): color {
+  // convert an array of linear-light a98-rgb values to CIE XYZ
+  // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+  // has greater numerical precision than section 4.3.5.3 of
+  // https://www.adobe.com/digitalimag/pdfs/AdobeRGB1998.pdf
+  // but the values below were calculated from first principles
+  // from the chromaticity coordinates of R G B W
+  // see matrixmaker.html
+  const M = [
+    [0.5766690429101305, 0.1855582379065463, 0.1882286462349947],
+    [0.29734497525053605, 0.6273635662554661, 0.07529145849399788],
+    [0.02703136138641234, 0.07068885253582723, 0.9913375368376388],
+  ];
+
+  return multiplyMatrices(M, rgb) as color;
+}
+
+export function XYZ_to_lin_a98rgb(XYZ: color): color {
+  // convert XYZ to linear-light a98-rgb
+  const M = [
+    [2.0415879038107465, -0.5650069742788596, -0.34473135077832956],
+    [-0.9692436362808795, 1.8759675015077202, 0.04155505740717557],
+    [0.013444280632031142, -0.11836239223101838, 1.0151749943912054],
+  ];
+
+  return multiplyMatrices(M, XYZ) as color;
+}
+
+//Rec. 2020-related functions
+
+export function lin_2020(RGB: color): color {
+  // convert an array of rec2020 RGB values in the range 0.0 - 1.0
+  // to linear light (un-companded) form.
+  // ITU-R BT.2020-2 p.4
+
+  const α = 1.09929682680944;
+  const β = 0.018053968510807;
+
+  return RGB.map(function (val) {
+    const sign = val < 0 ? -1 : 1;
+    const abs = Math.abs(val);
+
+    if (abs < β * 4.5) {
+      return val / 4.5;
+    }
+
+    return sign * Math.pow((abs + α - 1) / α, 1 / 0.45);
+  }) as color;
+}
+
+export function gam_2020(RGB: color): color {
+  // convert an array of linear-light rec2020 RGB  in the range 0.0-1.0
+  // to gamma corrected form
+  // ITU-R BT.2020-2 p.4
+
+  const α = 1.09929682680944;
+  const β = 0.018053968510807;
+
+  return RGB.map(function (val) {
+    const sign = val < 0 ? -1 : 1;
+    const abs = Math.abs(val);
+
+    if (abs > β) {
+      return sign * (α * Math.pow(abs, 0.45) - (α - 1));
+    }
+
+    return 4.5 * val;
+  }) as color;
+}
+
+export function lin_2020_to_XYZ(rgb: color): color {
+  // convert an array of linear-light rec2020 values to CIE XYZ
+  // using  D65 (no chromatic adaptation)
+  // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+  const M = [
+    [0.6369580483012914, 0.14461690358620832, 0.1688809751641721],
+    [0.2627002120112671, 0.6779980715188708, 0.05930171646986196],
+    [0.0, 0.028072693049087428, 1.060985057710791],
+  ];
+  // 0 is actually calculated as  4.994106574466076e-17
+
+  return multiplyMatrices(M, rgb) as color;
+}
+
+export function XYZ_to_lin_2020(XYZ: color): color {
+  // convert XYZ to linear-light rec2020
+  const M = [
+    [1.7166511879712674, -0.35567078377639233, -0.25336628137365974],
+    [-0.6666843518324892, 1.6164812366349395, 0.01576854581391113],
+    [0.017639857445310783, -0.042770613257808524, 0.9421031212354738],
+  ];
+
+  return multiplyMatrices(M, XYZ) as color;
+}
+
+// Chromatic adaptation
+
+export function D65_to_D50(XYZ: color): color {
+  // Bradford chromatic adaptation from D65 to D50
+  // The matrix below is the result of three operations:
+  // - convert from XYZ to retinal cone domain
+  // - scale components from one reference white to another
+  // - convert back to XYZ
+  // http://www.brucelindbloom.com/index.html?Eqn_ChromAdapt.html
+  const M = [
+    [1.0479298208405488, 0.022946793341019088, -0.05019222954313557],
+    [0.029627815688159344, 0.990434484573249, -0.01707382502938514],
+    [-0.009243058152591178, 0.015055144896577895, 0.7518742899580008],
+  ];
+
+  return multiplyMatrices(M, XYZ) as color;
+}
+
+export function D50_to_D65(XYZ: color): color {
+  // Bradford chromatic adaptation from D50 to D65
+  const M = [
+    [0.9554734527042182, -0.023098536874261423, 0.0632593086610217],
+    [-0.028369706963208136, 1.0099954580058226, 0.021041398966943008],
+    [0.012314001688319899, -0.020507696433477912, 1.3303659366080753],
+  ];
+
+  return multiplyMatrices(M, XYZ) as color;
+}
+
+// CIE Lab and LCH
+
+export function XYZ_to_Lab(XYZ: color): color {
+  // Assuming XYZ is relative to D50, convert to CIE Lab
+  // from CIE standard, which now defines these as a rational fraction
+  const ε = 216 / 24389; // 6^3/29^3
+  const κ = 24389 / 27; // 29^3/3^3
+
+  // compute xyz, which is XYZ scaled relative to reference white
+  const xyz = XYZ.map((value, i) => value / D50[i]);
+
+  // now compute f
+  const f = xyz.map((value) =>
+    value > ε ? Math.cbrt(value) : (κ * value + 16) / 116,
+  );
+
+  return [
+    116 * f[1] - 16, // L
+    500 * (f[0] - f[1]), // a
+    200 * (f[1] - f[2]), // b
+  ];
+  // L in range [0,100]. For use in CSS, add a percent
+}
+
+export function Lab_to_XYZ(Lab: color): color {
+  // Convert Lab to D50-adapted XYZ
+  // http://www.brucelindbloom.com/index.html?Eqn_RGB_XYZ_Matrix.html
+  const κ = 24389 / 27; // 29^3/3^3
+  const ε = 216 / 24389; // 6^3/29^3
+  const f = [];
+
+  // compute f, starting with the luminance-related term
+  f[1] = (Lab[0] + 16) / 116;
+  f[0] = Lab[1] / 500 + f[1];
+  f[2] = f[1] - Lab[2] / 200;
+
+  // compute xyz
+  const xyz = [
+    Math.pow(f[0], 3) > ε ? Math.pow(f[0], 3) : (116 * f[0] - 16) / κ,
+    Lab[0] > κ * ε ? Math.pow((Lab[0] + 16) / 116, 3) : Lab[0] / κ,
+    Math.pow(f[2], 3) > ε ? Math.pow(f[2], 3) : (116 * f[2] - 16) / κ,
+  ];
+
+  // Compute XYZ by scaling xyz by reference white
+  return xyz.map((value, i) => value * D50[i]) as color;
+}
+
+export function Lab_to_LCH(Lab: color): color {
+  // Convert to polar form
+  const hue = (Math.atan2(Lab[2], Lab[1]) * 180) / Math.PI;
+  return [
+    Lab[0], // L is still L
+    Math.sqrt(Math.pow(Lab[1], 2) + Math.pow(Lab[2], 2)), // Chroma
+    hue >= 0 ? hue : hue + 360, // Hue, in degrees [0 to 360)
+  ];
+}
+
+export function LCH_to_Lab(LCH: color): color {
+  // Convert from polar form
+  return [
+    LCH[0], // L is still L
+    LCH[1] * Math.cos((LCH[2] * Math.PI) / 180), // a
+    LCH[1] * Math.sin((LCH[2] * Math.PI) / 180), // b
+  ];
+}
+
+// OKLab and OKLCH
+// https://bottosson.github.io/posts/oklab/
+
+// XYZ <-> LMS matrices recalculated for consistent reference white
+// see https://github.com/w3c/csswg-drafts/issues/6642#issuecomment-943521484
+
+export function XYZ_to_OKLab(XYZ: color): color {
+  // Given XYZ relative to D65, convert to OKLab
+  const XYZtoLMS = [
+    [0.8190224432164319, 0.3619062562801221, -0.12887378261216414],
+    [0.0329836671980271, 0.9292868468965546, 0.03614466816999844],
+    [0.048177199566046255, 0.26423952494422764, 0.6335478258136937],
+  ];
+  const LMStoOKLab = [
+    [0.2104542553, 0.793617785, -0.0040720468],
+    [1.9779984951, -2.428592205, 0.4505937099],
+    [0.0259040371, 0.7827717662, -0.808675766],
+  ];
+
+  const LMS = multiplyMatrices(XYZtoLMS, XYZ) as color;
+  return multiplyMatrices(
+    LMStoOKLab,
+    LMS.map((c) => Math.cbrt(c)),
+  ) as color;
+  // L in range [0,1]. For use in CSS, multiply by 100 and add a percent
+}
+
+export function OKLab_to_XYZ(OKLab: color): color {
+  // Given OKLab, convert to XYZ relative to D65
+  const LMStoXYZ = [
+    [1.2268798733741557, -0.5578149965554813, 0.28139105017721583],
+    [-0.04057576262431372, 1.1122868293970594, -0.07171106666151701],
+    [-0.07637294974672142, -0.4214933239627914, 1.5869240244272418],
+  ];
+  const OKLabtoLMS = [
+    [0.99999999845051981432, 0.39633779217376785678, 0.21580375806075880339],
+    [1.0000000088817607767, -0.1055613423236563494, -0.063854174771705903402],
+    [1.0000000546724109177, -0.089484182094965759684, -1.2914855378640917399],
+  ];
+
+  const LMSnl = multiplyMatrices(OKLabtoLMS, OKLab) as color;
+  return multiplyMatrices(
+    LMStoXYZ,
+    LMSnl.map((c) => c ** 3),
+  ) as color;
+}
+
+export function OKLab_to_OKLCH(OKLab: color): color {
+  const hue = (Math.atan2(OKLab[2], OKLab[1]) * 180) / Math.PI;
+  return [
+    OKLab[0], // L is still L
+    Math.sqrt(OKLab[1] ** 2 + OKLab[2] ** 2), // Chroma
+    hue >= 0 ? hue : hue + 360, // Hue, in degrees [0 to 360)
+  ];
+}
+
+export function OKLCH_to_OKLab(OKLCH: color): color {
+  return [
+    OKLCH[0], // L is still L
+    OKLCH[1] * Math.cos((OKLCH[2] * Math.PI) / 180), // a
+    OKLCH[1] * Math.sin((OKLCH[2] * Math.PI) / 180), // b
+  ];
+}
+
+// Premultiplied alpha conversions
+
+export function rectangular_premultiply(color: color, alpha: number): color {
+  // given a color in a rectangular orthogonal colorspace
+  // and an alpha value
+  // return the premultiplied form
+  return color.map((c) => c * alpha) as color;
+}
+
+export function rectangular_un_premultiply(color: color, alpha: number): color {
+  // given a premultiplied color in a rectangular orthogonal colorspace
+  // and an alpha value
+  // return the actual color
+  if (alpha === 0) {
+    return color; // avoid divide by zero
+  }
+  return color.map((c) => c / alpha) as color;
+}
+
+export function polar_premultiply(
+  color: color,
+  alpha: number,
+  hueIndex: number,
+): color {
+  // given a color in a cylindicalpolar colorspace
+  // and an alpha value
+  // return the premultiplied form.
+  // the index says which entry in the color array corresponds to hue angle
+  // for example, in OKLCH it would be 2
+  // while in HSL it would be 0
+  return color.map((c, i) => c * (hueIndex === i ? 1 : alpha)) as color;
+}
+
+export function polar_un_premultiply(
+  color: color,
+  alpha: number,
+  hueIndex: number,
+): color {
+  // given a color in a cylindicalpolar colorspace
+  // and an alpha value
+  // return the actual color.
+  // the hueIndex says which entry in the color array corresponds to hue angle
+  // for example, in OKLCH it would be 2
+  // while in HSL it would be 0
+  if (alpha === 0) {
+    return color; // avoid divide by zero
+  }
+  return color.map((c, i) => c / (hueIndex === i ? 1 : alpha)) as color;
+}
+
+// Convenience functions can easily be defined, such as
+export function hsl_premultiply(color: color, alpha: number): color {
+  return polar_premultiply(color, alpha, 0);
+}

--- a/libs/css-color-4/src/css-color-4/delta-eok.ts
+++ b/libs/css-color-4/src/css-color-4/delta-eok.ts
@@ -1,0 +1,21 @@
+/**
+ * @license W3C
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ *
+ * @copyright This software or document includes material copied from or derived from https://github.com/w3c/csswg-drafts/blob/main/css-color-4/deltaEOK.js. Copyright © 2022 W3C® (MIT, ERCIM, Keio, Beihang).
+ *
+ * @see https://github.com/w3c/csswg-drafts/blob/main/css-color-4/deltaEOK.js
+ */
+
+// Calculate deltaE OK
+// simple root sum of squares
+type color = [number, number, number];
+export function deltaEOK(reference: color, sample: color): number {
+  // Given reference and sample are both in OKLab
+  const [L1, a1, b1] = reference;
+  const [L2, a2, b2] = sample;
+  const ΔL = L1 - L2;
+  const Δa = a1 - a2;
+  const Δb = b1 - b2;
+  return Math.sqrt(ΔL ** 2 + Δa ** 2 + Δb ** 2);
+}

--- a/libs/css-color-4/src/css-color-4/map-gamut.ts
+++ b/libs/css-color-4/src/css-color-4/map-gamut.ts
@@ -1,0 +1,64 @@
+import { OKLCH_to_OKLab } from './conversions';
+import { deltaEOK } from './delta-eok';
+
+type color = [number, number, number];
+
+export function mapGamut(
+  startOKLCH: color,
+  toDestination: (x: color) => color,
+  fromDestination: (x: color) => color,
+): color {
+  return binarySearchGamut(startOKLCH, toDestination, fromDestination);
+}
+
+function binarySearchGamut(
+  startOKLCH: color,
+  toDestination: (x: color) => color,
+  fromDestination: (x: color) => color,
+): color {
+  let min = 0;
+  let max = startOKLCH[1];
+  const current = startOKLCH;
+
+  while (max - min > 0.0001) {
+    const clipped = clip(toDestination(current));
+    const deltaE = deltaEOK(
+      OKLCH_to_OKLab(current),
+      OKLCH_to_OKLab(fromDestination(clipped)),
+    );
+    // are we inside the gamut (or very close to the boundary, outside)
+    if (deltaE - 0.02 < 0.0001) {
+      min = current[1];
+    } else {
+      max = current[1];
+    }
+    // binary search
+    current[1] = (max + min) / 2;
+  }
+
+  return clip(toDestination([...current]));
+}
+
+export function clip(color: color): color {
+  return color.map((val) => {
+    if (val < 0) {
+      return 0;
+    } else if (val > 1) {
+      return 1;
+    } else {
+      return val;
+    }
+  }) as color;
+}
+
+export function inGamut(x: color): boolean {
+  const [xX, xY, xZ] = x;
+  return (
+    xX >= -0.0001 &&
+    xX <= 1.0001 &&
+    xY >= -0.0001 &&
+    xY <= 1.0001 &&
+    xZ >= -0.0001 &&
+    xZ <= 1.0001
+  );
+}

--- a/libs/css-color-4/src/css-color-4/multiply-matrices.ts
+++ b/libs/css-color-4/src/css-color-4/multiply-matrices.ts
@@ -1,0 +1,56 @@
+/**
+ * Simple matrix (and vector) multiplication
+ * Warning: No error handling for incompatible dimensions!
+ * @author Lea Verou 2020 MIT License
+ *
+ * @license W3C
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ *
+ * @copyright This software or document includes material copied from or derived from https://github.com/w3c/csswg-drafts/blob/main/css-color-4/multiply-matrices.js. Copyright © 2022 W3C® (MIT, ERCIM, Keio, Beihang).
+ *
+ * @see https://github.com/w3c/csswg-drafts/blob/main/css-color-4/multiply-matrices.js
+ */
+
+// A is m x n. B is n x p. product is m x p.
+export function multiplyMatrices(
+  a: Array<Array<number>> | Array<number>,
+  b: Array<Array<number>> | Array<number>,
+): Array<Array<number>> | Array<number> {
+  const m = a.length;
+
+  let A: Array<Array<number>>;
+  if (!Array.isArray(a[0])) {
+    // A is vector, convert to [[a, b, c, ...]]
+    A = [a as Array<number>];
+  } else {
+    A = a as Array<Array<number>>;
+  }
+
+  let B: Array<Array<number>>;
+  if (!Array.isArray(b[0])) {
+    // B is vector, convert to [[a], [b], [c], ...]]
+    B = (b as Array<number>).map((x) => [x]);
+  }
+
+  const p = B[0].length;
+  const B_cols = B[0].map((_, i) => B.map((x) => x[i])); // transpose B
+  let product: Array<Array<number>> | Array<number> = A.map((row) =>
+    B_cols.map((col) => {
+      if (!Array.isArray(row)) {
+        return col.reduce((d, f) => d + f * row, 0);
+      }
+
+      return row.reduce((d, f, i) => d + f * (col[i] || 0), 0);
+    }),
+  );
+
+  if (m === 1) {
+    product = product[0]; // Avoid [[a, b, c, ...]]
+  }
+
+  if (p === 1) {
+    return product.map((x) => x[0]); // Avoid [[a], [b], [c], ...]]
+  }
+
+  return product;
+}

--- a/libs/css-color-4/src/css-color-4/utilities.ts
+++ b/libs/css-color-4/src/css-color-4/utilities.ts
@@ -1,0 +1,258 @@
+/**
+ * @license W3C
+ * https://www.w3.org/Consortium/Legal/2015/copyright-software-and-document
+ *
+ * @copyright This software or document includes material copied from or derived from https://github.com/w3c/csswg-drafts/blob/main/css-color-4/utilities.js. Copyright © 2022 W3C® (MIT, ERCIM, Keio, Beihang).
+ *
+ * @see https://github.com/w3c/csswg-drafts/blob/main/css-color-4/utilities.js
+ */
+
+import {
+  D50_to_D65,
+  D65_to_D50,
+  gam_2020,
+  gam_P3,
+  gam_sRGB,
+  Lab_to_LCH,
+  Lab_to_XYZ,
+  LCH_to_Lab,
+  lin_2020,
+  lin_2020_to_XYZ,
+  lin_P3,
+  lin_P3_to_XYZ,
+  lin_sRGB,
+  lin_sRGB_to_XYZ,
+  XYZ_to_Lab,
+  XYZ_to_lin_2020,
+  XYZ_to_lin_P3,
+  XYZ_to_lin_sRGB,
+} from './conversions';
+
+type color = [number, number, number];
+
+// utility functions for color conversions
+// needs conversions.js
+
+export function sRGB_to_luminance(RGB: color): number {
+  // convert an array of gamma-corrected sRGB values
+  // in the 0.0 to 1.0 range
+  // to linear-light sRGB, then to CIE XYZ
+  // and return luminance (the Y value)
+
+  const XYZ = lin_sRGB_to_XYZ(lin_sRGB(RGB));
+  return XYZ[1];
+}
+
+export function contrast(RGB1: color, RGB2: color): number {
+  // return WCAG 2.1 contrast ratio
+  // https://www.w3.org/TR/WCAG21/#dfn-contrast-ratio
+  // for two sRGB values
+  // given as arrays of 0.0 to 1.0
+
+  const L1 = sRGB_to_luminance(RGB1);
+  const L2 = sRGB_to_luminance(RGB2);
+
+  if (L1 > L2) {
+    return (L1 + 0.05) / (L2 + 0.05);
+  }
+
+  return (L2 + 0.05) / (L1 + 0.05);
+}
+
+export function sRGB_to_LCH(RGB: color): color {
+  // convert an array of gamma-corrected sRGB values
+  // in the 0.0 to 1.0 range
+  // to linear-light sRGB, then to CIE XYZ,
+  // then adapt from D65 to D50,
+  // then convert XYZ to CIE Lab
+  // and finally, convert to CIE LCH
+
+  return Lab_to_LCH(XYZ_to_Lab(D65_to_D50(lin_sRGB_to_XYZ(lin_sRGB(RGB)))));
+}
+
+export function P3_to_LCH(RGB: color): color {
+  // convert an array of gamma-corrected display-p3 values
+  // in the 0.0 to 1.0 range
+  // to linear-light display-p3, then to CIE XYZ,
+  // then adapt from D65 to D50,
+  // then convert XYZ to CIE Lab
+  // and finally, convert to CIE LCH
+
+  return Lab_to_LCH(XYZ_to_Lab(D65_to_D50(lin_P3_to_XYZ(lin_P3(RGB)))));
+}
+
+export function r2020_to_LCH(RGB: color): color {
+  // convert an array of gamma-corrected rec.2020 values
+  // in the 0.0 to 1.0 range
+  // to linear-light sRGB, then to CIE XYZ,
+  // then adapt from D65 to D50,
+  // then convert XYZ to CIE Lab
+  // and finally, convert to CIE LCH
+
+  return Lab_to_LCH(XYZ_to_Lab(D65_to_D50(lin_2020_to_XYZ(lin_2020(RGB)))));
+}
+
+export function LCH_to_sRGB(LCH: color): color {
+  // convert an array of CIE LCH values
+  // to CIE Lab, and then to XYZ,
+  // adapt from D50 to D65,
+  // then convert XYZ to linear-light sRGB
+  // and finally to gamma corrected sRGB
+  // for in-gamut colors, components are in the 0.0 to 1.0 range
+  // out of gamut colors may have negative components
+  // or components greater than 1.0
+  // so check for that :)
+
+  return gam_sRGB(XYZ_to_lin_sRGB(D50_to_D65(Lab_to_XYZ(LCH_to_Lab(LCH)))));
+}
+
+export function LCH_to_P3(LCH: color): color {
+  // convert an array of CIE LCH values
+  // to CIE Lab, and then to XYZ,
+  // adapt from D50 to D65,
+  // then convert XYZ to linear-light display-p3
+  // and finally to gamma corrected display-p3
+  // for in-gamut colors, components are in the 0.0 to 1.0 range
+  // out of gamut colors may have negative components
+  // or components greater than 1.0
+  // so check for that :)
+
+  return gam_P3(XYZ_to_lin_P3(D50_to_D65(Lab_to_XYZ(LCH_to_Lab(LCH)))));
+}
+
+export function LCH_to_r2020(LCH: color): color {
+  // convert an array of CIE LCH values
+  // to CIE Lab, and then to XYZ,
+  // adapt from D50 to D65,
+  // then convert XYZ to linear-light rec.2020
+  // and finally to gamma corrected rec.2020
+  // for in-gamut colors, components are in the 0.0 to 1.0 range
+  // out of gamut colors may have negative components
+  // or components greater than 1.0
+  // so check for that :)
+
+  return gam_2020(XYZ_to_lin_2020(D50_to_D65(Lab_to_XYZ(LCH_to_Lab(LCH)))));
+}
+
+// this is straight from the CSS Color 4 spec
+
+export function hslToRgb(hsl: color): color {
+  // 	For simplicity, this algorithm assumes that the hue has been normalized
+  //  to a number in the half-open range [0, 6), and the saturation and lightness
+  //  have been normalized to the range [0, 1]. It returns an array of three numbers
+  //  representing the red, green, and blue channels of the colors,
+  //  normalized to the range [0, 1]
+  const [hue, sat, light] = hsl;
+
+  let t2: number;
+  if (light <= 0.5) {
+    t2 = light * (sat + 1);
+  } else {
+    t2 = light + sat - light * sat;
+  }
+  const t1 = light * 2 - t2;
+  const r = hueToRgb(t1, t2, hue + 2);
+  const g = hueToRgb(t1, t2, hue);
+  const b = hueToRgb(t1, t2, hue - 2);
+  return [r, g, b];
+}
+
+export function hueToRgb(t1: number, t2: number, hue: number): number {
+  if (hue < 0) {
+    hue += 6;
+  }
+  if (hue >= 6) {
+    hue -= 6;
+  }
+
+  if (hue < 1) {
+    return (t2 - t1) * hue + t1;
+  } else if (hue < 3) {
+    return t2;
+  } else if (hue < 4) {
+    return (t2 - t1) * (4 - hue) + t1;
+  } else {
+    return t1;
+  }
+}
+
+// These are the naive algorithms from CS Color 4
+
+export function naive_CMYK_to_sRGB(
+  CMYK: [number, number, number, number],
+): color {
+  // CMYK is an array of four values
+  // in the range [0.0, 1.0]
+  // the optput is an array of [RGB]
+  // also in the [0.0, 1.0] range
+  // because the naive algorithm does not generate out of gamut colors
+  // neither does it generate accurate simulations of practical CMYK colors
+
+  const cyan = CMYK[0],
+    magenta = CMYK[1],
+    yellow = CMYK[2],
+    black = CMYK[3];
+
+  const red = 1 - Math.min(1, cyan * (1 - black) + black);
+  const green = 1 - Math.min(1, magenta * (1 - black) + black);
+  const blue = 1 - Math.min(1, yellow * (1 - black) + black);
+
+  return [red, green, blue];
+}
+
+export function naive_sRGB_to_CMYK(
+  RGB: color,
+): [number, number, number, number] {
+  // RGB is an arravy of three values
+  // in the range [0.0, 1.0]
+  // the output is an array of [CMYK]
+  // also in the [0.0, 1.0] range
+  // with maximum GCR and (I think) 200% TAC
+  // the naive algorithm does not generate out of gamut colors
+  // neither does it generate accurate simulations of practical CMYK colors
+
+  const red = RGB[0],
+    green = RGB[1],
+    blue = RGB[2];
+
+  const black = 1 - Math.max(red, green, blue);
+  const cyan = black == 1.0 ? 0 : (1 - red - black) / (1 - black);
+  const magenta = black == 1.0 ? 0 : (1 - green - black) / (1 - black);
+  const yellow = black == 1.0 ? 0 : (1 - blue - black) / (1 - black);
+
+  return [cyan, magenta, yellow, black];
+}
+
+// Chromaticity utilities
+
+export function XYZ_to_xy(XYZ: color): [number, number] {
+  // Convert an array of three XYZ values
+  // to x,y chromaticity coordinates
+
+  const X = XYZ[0];
+  const Y = XYZ[1];
+  const Z = XYZ[2];
+  const sum = X + Y + Z;
+  return [X / sum, Y / sum];
+}
+
+export function xy_to_uv(xy: [number, number]): [number, number] {
+  // convert an x,y chromaticity pair
+  // to u*,v* chromaticities
+
+  const x = xy[0];
+  const y = xy[1];
+  const denom = -2 * x + 12 * y + 3;
+  return [(4 * x) / denom, (9 * y) / denom];
+}
+
+export function XYZ_to_uv(XYZ: color): [number, number] {
+  // Convert an array of three XYZ values
+  // to u*,v* chromaticity coordinates
+
+  const X = XYZ[0];
+  const Y = XYZ[1];
+  const Z = XYZ[2];
+  const denom = X + 15 * Y + 3 * Z;
+  return [(4 * X) / denom, (9 * Y) / denom];
+}

--- a/libs/css-color-4/src/index.ts
+++ b/libs/css-color-4/src/index.ts
@@ -1,0 +1,1 @@
+export { oklchToSRgb } from './convert-oklch-to-srgb';

--- a/libs/css-color-4/tsconfig.json
+++ b/libs/css-color-4/tsconfig.json
@@ -1,0 +1,8 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@os/tsconfig/lib.json",
+  "compilerOptions": {
+    "baseUrl": "."
+  },
+  "include": ["src"]
+}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1947,6 +1947,7 @@ __metadata:
     "@iconify-json/ri": ^1.1.1
     "@intlify/vite-plugin-vue-i18n": ^3.4.0
     "@os/ability": "workspace:*"
+    "@os/css-color-4": "workspace:*"
     "@os/eslint-config": "workspace:*"
     "@testing-library/user-event": 14.1.1
     "@testing-library/vue": ^6.5.1
@@ -1979,6 +1980,17 @@ __metadata:
     vue-tsc: 0.34.15
     whatwg-fetch: ^3.6.2
     windicss: ^3.5.4
+  languageName: unknown
+  linkType: soft
+
+"@os/css-color-4@workspace:*, @os/css-color-4@workspace:libs/css-color-4":
+  version: 0.0.0-use.local
+  resolution: "@os/css-color-4@workspace:libs/css-color-4"
+  dependencies:
+    rollup: ^2.74.1
+    rollup-plugin-dts: ^4.2.1
+    rollup-plugin-esbuild: ^4.9.1
+    typescript: ~4.7.2
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
You can ignore all code in `libs/css-color-4`. This code is lifted from external sources and supports generating lch color palettes.

- Default across themes: light, dark, stone
- Per theme: primary, gray, caution, danger, info, success (secondary, tertiary is removed)
- Demo only buttons in primary and danger
- Update all styles